### PR TITLE
Retrieve properly the tweet text_content

### DIFF
--- a/lib/tweet_deletion/tweet.rb
+++ b/lib/tweet_deletion/tweet.rb
@@ -53,7 +53,7 @@ class Tweet < Status
   end
 
   def text_content
-    @status.full_text
+    @status.attrs[:full_text]
   end
 
   def html_content


### PR DESCRIPTION
For some reason, we cannot access full_text directly anymore but have to go through attrs now.