### PR TITLE
Do not fails when deleting an inexisting tweet

### DIFF
--- a/lib/tweet_deletion/tweet.rb
+++ b/lib/tweet_deletion/tweet.rb
@@ -53,7 +53,7 @@ class Tweet < Status
   end
 
   def text_content
-    @status.attrs[:full_text]
+    @status.attrs[:full_text] || @status.attrs[:text]
   end
 
   def html_content

--- a/lib/tweet_deletion/twitter.rb
+++ b/lib/tweet_deletion/twitter.rb
@@ -28,13 +28,13 @@ module TweetDeletion
     end
 
     def with_user_favorites
-      tweets = @client.favorites(count: default_slice, tweet_mode: 'extended')
+      tweets = @client.favorites(count: default_slice, include_entities: true, tweet_mode: 'extended')
       while tweets.any?
         last_id = tweets.last.id
         tweets.each do |tweet|
           yield yieldable_status(tweet)
         end
-        tweets = @client.favorites(count: default_slice, tweet_mode: 'extended', max_id: last_id - 1)
+        tweets = @client.favorites(count: default_slice, include_entities: true, tweet_mode: 'extended', max_id: last_id - 1)
       end
     end
 
@@ -67,22 +67,22 @@ module TweetDeletion
     end
 
     def with_user_statuses(include_rts: true, exclude_replies: false)
-      tweets = @client.user_timeline(count: default_slice, include_rts: include_rts, exclude_replies: exclude_replies, tweet_mode: 'extended')
+      tweets = @client.user_timeline(count: default_slice, include_rts: include_rts, include_entities: true, exclude_replies: exclude_replies, tweet_mode: 'extended')
       while tweets.any? 
         tweets.each do |tweet|
           yield yieldable_status(tweet)
         end
-        tweets = @client.user_timeline(count: default_slice, include_rts: include_rts, exclude_replies: exclude_replies, max_id: tweets.last.id - 1, tweet_mode: 'extended')
+        tweets = @client.user_timeline(count: default_slice, include_rts: include_rts, include_entities: true, exclude_replies: exclude_replies, max_id: tweets.last.id - 1, tweet_mode: 'extended')
       end
     end
 
     def with_user_retweets
-      tweets = @client.retweeted_by_me(count: 100, exclude_replies: false, tweet_mode: 'extended')
+      tweets = @client.retweeted_by_me(count: 100, exclude_replies: false, include_entities: true, tweet_mode: 'extended')
       while tweets.any?
         tweets.each do |tweet|
           yield yieldable_status(tweet)
         end
-        tweets = @client.retweeted_by_me(count: 100, exclude_replies: false, max_id: tweets.last.id - 1, tweet_mode: 'extended')
+        tweets = @client.retweeted_by_me(count: 100, exclude_replies: false, include_entities: true, max_id: tweets.last.id - 1, tweet_mode: 'extended')
       end
     end
 

--- a/lib/tweet_deletion/twitter.rb
+++ b/lib/tweet_deletion/twitter.rb
@@ -52,7 +52,18 @@ module TweetDeletion
     end
 
     def destroy_status(tweet)
-      @client.destroy_status(tweet)
+      begin
+        @client.destroy_status(tweet)
+      rescue ::Twitter::Error::NotFound
+        # Tweet ID is still in timeline
+        # but cannot be deleted because
+        # it is marked as already deleted
+        # It may happen for RT of deleted tweets
+        # or RT of blocked accounts
+        # example : https://twitter.com/inclusicomps/status/843228546176864256
+        # and RT as : https://twitter.com/edas/status/843374966141829120
+        # Let's ignore it as we can't do anything with it anyways
+      end
     end
 
     def with_user_statuses(include_rts: true, exclude_replies: false)


### PR DESCRIPTION
This can happen for RTs of deleted tweets or blocked account, as a bug/problem on Twitter's side.